### PR TITLE
Releases are failing because of incorrect InstallBuilder download link

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ jobs:
     env:
       INSTALLBUILDER: installbuilder
       INSTALLBUILDER_LICENSE: ${{ secrets.INSTALLBUILDER_LICENSE }}
-      INSTALLBUILDER_VERSION: ${{ secrets.INSTALLBUILDER_VERSION }}
       UPLOAD_API_KEY: ${{ secrets.UPLOAD_API_KEY }}
     steps:
       - uses: actions/checkout@v3
-      - name: Download and install VMware InstallBuilder
+      - name: Download and install InstallBuilder
         run: |
           set -e
-          curl -sSL https://releases.installbuilder.com/installbuilder/installbuilder-qt-enterprise-$INSTALLBUILDER_VERSION-linux-x64-installer.run -o installbuilder.run
+          INSTALLBUILDER_VERSION=$(curl --fail-with-body https://installbuilder.com/VERSION)
+          curl --fail-with-body -sSL https://releases.installbuilder.com/installbuilder/installbuilder-qt-enterprise-$INSTALLBUILDER_VERSION-linux-x64-installer.run -o installbuilder.run
           chmod a+x installbuilder.run
           ./installbuilder.run --prefix "$INSTALLBUILDER" --mode unattended
           echo "$INSTALLBUILDER_LICENSE" > "${INSTALLBUILDER}/license.xml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Download and install InstallBuilder
         run: |
           set -e
-          INSTALLBUILDER_VERSION=$(curl --fail-with-body https://installbuilder.com/VERSION)
-          curl --fail-with-body -sSL https://releases.installbuilder.com/installbuilder/installbuilder-qt-enterprise-$INSTALLBUILDER_VERSION-linux-x64-installer.run -o installbuilder.run
+          INSTALLBUILDER_VERSION=$(curl --fail https://installbuilder.com/VERSION)
+          curl --fail -sSL https://releases.installbuilder.com/installbuilder/installbuilder-qt-enterprise-$INSTALLBUILDER_VERSION-linux-x64-installer.run -o installbuilder.run
           chmod a+x installbuilder.run
           ./installbuilder.run --prefix "$INSTALLBUILDER" --mode unattended
           echo "$INSTALLBUILDER_LICENSE" > "${INSTALLBUILDER}/license.xml"


### PR DESCRIPTION
The builds are currently failing because they are trying to download a specific version from InstallBuilder releases server. Releases are not kept public forever so that is not a reliable way. The best way would be to either cache the version into your own server or simply use the latest. 

This is just an example fixing it by getting the latest version instructed by [https://installbuilder.com/VERSION](https://installbuilder.com/VERSION). The drawback is that you are not pinned to a fixed version but you gain getting automatic vulnerability fixes for free.
