### PR TITLE
github-actions: Add gchat notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,3 +105,15 @@ jobs:
             aws s3 cp --acl public-read bndiagnostic-$version_name-linux-$arch.run $S3_URL/latest/bndiagnostic-linux-$arch.run
           done
           aws s3 cp --acl public-read bndiagnostic-update.xml $S3_URL/latest/
+  notify:
+    name: Send notification
+    needs:
+      - release
+      - upload
+    if: ${{ always() && (needs.release.result == 'failure' || needs.upload.result == 'failure') }}
+    uses: bitnami/support/.github/workflows/gchat-notification.yml@main
+    with:
+      workflow: ${{ github.workflow }}
+      job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      webhook-url: ${{ secrets.GCHAT_CONTENT_ALERTS_WEBHOOK_URL }}


### PR DESCRIPTION
### Description of the change

This PR adds GChat notifications to the CD pipeline.

When the pipeline fails, it will notify the team with a message using the gchat-notification worflow from bitnami/support

### Possible drawbacks

None known.
