### PR TITLE
[bitnami/diagnostics] chore(workflows): Avoid running workflows in forked repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             bndiagnostic-*.run
   release:
     needs: ['build']
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'bitnami/bndiagnostic' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     name: Release
     env:
@@ -75,7 +75,6 @@ jobs:
           fi
   upload:
     needs: ['build', 'release']
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     name: Upload
     env:


### PR DESCRIPTION
### Description of the change

Check repository to avoid running scheduled or CD workflows in forked repositories.

### Benefits

Skip unnecessary executions and failures in forks.

### Possible drawbacks

None

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
