### PR TITLE
fix(main.yml): Use 'verify' label to manage the execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && github.event.label.name == 'verify') }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:


### PR DESCRIPTION
### Description of the change

Use `verify` label to control the workflow execution.

### Benefits

Avoid building untrusted code.

### Possible drawbacks

We will need to add `verify` label manually.

### Applicable issues

- https://github.com/bitnami/bndiagnostic/security/code-scanning/13

